### PR TITLE
2.51.2: Wrong language on init user page

### DIFF
--- a/internal/api/ui/login/init_user_handler.go
+++ b/internal/api/ui/login/init_user_handler.go
@@ -100,7 +100,7 @@ func (l *Login) checkUserInitCode(w http.ResponseWriter, r *http.Request, authRe
 		l.renderInitUser(w, r, authReq, data.UserID, data.LoginName, "", data.PasswordSet, err)
 		return
 	}
-	l.renderInitUserDone(w, r, authReq, userOrgID)
+	l.renderInitUserDone(w, r, authReq, data.UserID, userOrgID)
 }
 
 func (l *Login) resendUserInit(w http.ResponseWriter, r *http.Request, authReq *domain.AuthRequest, userID string, loginName string, showPassword bool) {
@@ -168,11 +168,17 @@ func (l *Login) renderInitUser(w http.ResponseWriter, r *http.Request, authReq *
 	l.renderer.RenderTemplate(w, r, translator, l.renderer.Templates[tmplInitUser], data, nil)
 }
 
-func (l *Login) renderInitUserDone(w http.ResponseWriter, r *http.Request, authReq *domain.AuthRequest, orgID string) {
+func (l *Login) renderInitUserDone(w http.ResponseWriter, r *http.Request, authReq *domain.AuthRequest, userID, orgID string) {
 	translator := l.getTranslator(r.Context(), authReq)
 	data := l.getUserData(r, authReq, translator, "InitUserDone.Title", "InitUserDone.Description", "", "")
 	if authReq == nil {
 		l.customTexts(r.Context(), translator, orgID)
+		user, err := l.query.GetUserByID(r.Context(), false, userID)
+		if err == nil {
+			if preferredLanguage := user.Human.PreferredLanguage.String(); preferredLanguage != "" {
+				translator.SetPreferredLanguages(preferredLanguage)
+			}
+		}
 	}
 	l.renderer.RenderTemplate(w, r, translator, l.renderer.Templates[tmplInitUserDone], data, nil)
 }


### PR DESCRIPTION
### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
